### PR TITLE
feat 동적라우팅 에러 수정

### DIFF
--- a/s-blog/src/app/posts/[slug]/page.tsx
+++ b/s-blog/src/app/posts/[slug]/page.tsx
@@ -3,15 +3,15 @@ import PostNavigation from "@/components/PostNavigation";
 import { getPostData } from "@/service/posts";
 import Image from "next/image";
 
-interface ParamsProps {
-  params: {
+type Props = {
+  params: Promise<{
     slug: string;
-  };
-}
+  }>;
+};
 
-export default async function PostPage({ params }: ParamsProps) {
-  const { slug } = await Promise.resolve(params);
-  const post = await getPostData(slug);
+export default async function PostPage(props: Props) {
+  const params = await props.params;
+  const post = await getPostData(params.slug);
 
   return (
     <article>


### PR DESCRIPTION
 ## 동적라우팅 에러 수정
 #### 원인
Next.js 13+에서는 동적 라우트의 params가 비동기적으로 처리되어야 하는 객체입니다. 위 코드에서는 params를 동기적으로 구조분해할당하려 했기 때문에 에러가 발생

 #### 해결
props의 params타입 promise타입으로 정의
await된 params에서 slug 값을 안전하게 접근후 데이터 가져오기